### PR TITLE
Fix possibly related to App Store rejection

### DIFF
--- a/ImageAdditions/UIImage+ImageColoring.m
+++ b/ImageAdditions/UIImage+ImageColoring.m
@@ -179,7 +179,7 @@ static inline void HSLToRGB(CGFloat h, CGFloat s, CGFloat l, CGFloat * r, CGFloa
 }
 
 - (UIColor *) averageColorAtPixel:(CGPoint)pixel radius:(CGFloat)radius {
-	if ([self respondsToSelector:@selector(scale:)]) {
+	if ([self respondsToSelector:@selector(scale)]) {
 		CGFloat scale = [self scale];
 		pixel = CGPointMake(pixel.x*scale, pixel.y*scale);
 		radius *= scale;


### PR DESCRIPTION
I recently got rejected for using a private API called "scale:".  The only place I see anything called that is in UIImage+ImageColoring, and it appeared to be a typo where you ask for "@selector(scale:)", instead of "@selector(scale)".  I guess even if it doesn't turn out that this is why we got rejected, I'd at least contribute the fix.

So there's one, one character change: :)

Correcting typo where 'respondsToSelector:@selector(scale:)' is used instead of 'respondsToSelector:@selector(scale)'

Thanks for your work!
